### PR TITLE
Support https-only sources by requiring source to be a full url

### DIFF
--- a/boards/default.yml
+++ b/boards/default.yml
@@ -1,5 +1,5 @@
 defaults:
-  source: localhost:9090
+  source: http://localhost:9090
   from: now-1h
   to: now
   max_series: 10

--- a/explorer.go
+++ b/explorer.go
@@ -112,7 +112,7 @@ func handleNameAutocomplete(w http.ResponseWriter, req *http.Request) {
 
 	matchRE, err := regexp.Compile(match)
 	if err != nil {
-		log.Printf("decoding names: %s", err)
+		log.Printf("compiling match: %s", err)
 		return
 	}
 
@@ -123,7 +123,7 @@ func handleNameAutocomplete(w http.ResponseWriter, req *http.Request) {
 	enc := json.NewEncoder(w)
 
 	if !cached {
-		resp, err := http.Get("http://" + source + "/api/v1/label/__name__/values")
+		resp, err := http.Get(source + "/api/v1/label/__name__/values")
 		if err != nil {
 			log.Printf("getting names: %s", err)
 			return

--- a/static/board.js
+++ b/static/board.js
@@ -383,7 +383,7 @@ function createChart(name, config, global) {
     titleNode.textContent = config.name ? eval("`"+config.name+"`") : name;
     titleEl.title = queries.map(q => q.query).join("\n");
 
-    let chartURL = new URL(`${location.protocol}//${global.defaults.source}/graph`);
+    let chartURL = new URL(`${global.defaults.source}/graph`);
     queries.forEach((query, idx) => {
       chartURL.searchParams.set(`g${idx}.expr`, query.query);
       chartURL.searchParams.set(`g${idx}.tab`, "0"); // display graph
@@ -441,7 +441,7 @@ function createChart(name, config, global) {
 }
 
 async function fetchDataset(config, global) {
-  let u = new URL(`${location.protocol}//${global.defaults.source}/api/v1/query_range`);
+  let u = new URL(`${global.defaults.source}/api/v1/query_range`);
   u.searchParams.set("query", config.query);
 
   let from = toDate(config.from || global.defaults.from);

--- a/static/explore.js
+++ b/static/explore.js
@@ -33,7 +33,7 @@ searchEl.onkeydown = (ev) => {
 }
 
 function listSeries() {
-  let u = new URL(`${location.protocol}//${config.defaults.source}/api/v1/series`);
+  let u = new URL(`${config.defaults.source}/api/v1/series`);
   let searchStart = new Date();
   searchStart.setHours(searchStart.getHours() - 6);
   u.searchParams.set("match[]", searchEl.value);


### PR DESCRIPTION
We now don't try to guess the protocol anymore, we just require it to be a full url including the protocol.

That simplifies the code and makes it possible to require https.

Closes #1.